### PR TITLE
Covidregionaldata localisation

### DIFF
--- a/R/update-afghanistan.R
+++ b/R/update-afghanistan.R
@@ -2,7 +2,6 @@ source(here::here("R", "update-regional.R"))
 
 update_regional(region_name = "afghanistan",
                 covid_regional_data_identifier = "afghanistan",
-                cases_subregion_source =  "province",
                 case_modifier_function = function(cases){
                   cases <- cases[!is.na(iso_3166_2)]
                   return(cases)

--- a/R/update-afghanistan.R
+++ b/R/update-afghanistan.R
@@ -1,7 +1,6 @@
 source(here::here("R", "update-regional.R"))
 
 update_regional(region_name = "afghanistan",
-                covid_regional_data_identifier = "afghanistan",
                 case_modifier_function = function(cases){
                   cases <- cases[!is.na(iso_3166_2)]
                   return(cases)

--- a/R/update-belgium.R
+++ b/R/update-belgium.R
@@ -1,5 +1,3 @@
 source(here::here("R", "update-regional.R"))
 
-update_regional(region_name = "belgium",
-                covid_regional_data_identifier = "Belgium"
-)
+update_regional(region_name = "belgium")

--- a/R/update-brazil.R
+++ b/R/update-brazil.R
@@ -1,5 +1,3 @@
 source(here::here("R", "update-regional.R"))
 
-update_regional(region_name = "brazil",
-                covid_regional_data_identifier = "Brazil"
-)
+update_regional(region_name = "brazil")

--- a/R/update-brazil.R
+++ b/R/update-brazil.R
@@ -1,6 +1,5 @@
 source(here::here("R", "update-regional.R"))
 
 update_regional(region_name = "brazil",
-                covid_regional_data_identifier = "Brazil",
-                cases_subregion_source =  "state"
+                covid_regional_data_identifier = "Brazil"
 )

--- a/R/update-canada.R
+++ b/R/update-canada.R
@@ -1,5 +1,3 @@
 source(here::here("R", "update-regional.R"))
 
-update_regional(region_name = "canada",
-                covid_regional_data_identifier = "Canada"
-)
+update_regional(region_name = "canada")

--- a/R/update-canada.R
+++ b/R/update-canada.R
@@ -1,6 +1,5 @@
 source(here::here("R", "update-regional.R"))
 
 update_regional(region_name = "canada",
-                covid_regional_data_identifier = "Canada",
-                cases_subregion_source =  "province"
+                covid_regional_data_identifier = "Canada"
 )

--- a/R/update-colombia.R
+++ b/R/update-colombia.R
@@ -1,6 +1,5 @@
 source(here::here("R", "update-regional.R"))
 
 update_regional(region_name = "colombia",
-                covid_regional_data_identifier = "Colombia",
-                cases_subregion_source =  "departamento"
+                covid_regional_data_identifier = "Colombia"
 )

--- a/R/update-colombia.R
+++ b/R/update-colombia.R
@@ -1,5 +1,3 @@
 source(here::here("R", "update-regional.R"))
 
-update_regional(region_name = "colombia",
-                covid_regional_data_identifier = "Colombia"
-)
+update_regional(region_name = "colombia")

--- a/R/update-germany.R
+++ b/R/update-germany.R
@@ -1,6 +1,5 @@
 source(here::here("R", "update-regional.R"))
 
 update_regional(region_name = "germany",
-                covid_regional_data_identifier = "Germany",
-                cases_subregion_source =  "bundesland"
+                covid_regional_data_identifier = "Germany"
 )

--- a/R/update-germany.R
+++ b/R/update-germany.R
@@ -1,5 +1,3 @@
 source(here::here("R", "update-regional.R"))
 
-update_regional(region_name = "germany",
-                covid_regional_data_identifier = "Germany"
-)
+update_regional(region_name = "germany")

--- a/R/update-india.R
+++ b/R/update-india.R
@@ -1,6 +1,5 @@
 source(here::here("R", "update-regional.R"))
 
 update_regional(region_name = "india",
-                covid_regional_data_identifier = "India",
-                cases_subregion_source =  "state"
+                covid_regional_data_identifier = "India"
 )

--- a/R/update-india.R
+++ b/R/update-india.R
@@ -1,5 +1,3 @@
 source(here::here("R", "update-regional.R"))
 
-update_regional(region_name = "india",
-                covid_regional_data_identifier = "India"
-)
+update_regional(region_name = "india")

--- a/R/update-italy.R
+++ b/R/update-italy.R
@@ -1,5 +1,3 @@
 source(here::here("R", "update-regional.R"))
 
-update_regional(region_name = "italy",
-                covid_regional_data_identifier = "Italy"
-)
+update_regional(region_name = "italy")

--- a/R/update-regional.R
+++ b/R/update-regional.R
@@ -14,7 +14,8 @@ source(here::here("R", "utils.R"))
 #'
 #' @description Processes regional data in an abstract fashion to reduce code duplication
 #' @param region_name String, name of region, used for filepaths and filenames
-#' @param covid_regional_data_identifier String, region identifier used by covidregionaldata to get the data #todo audit which countries this differs from name and standardise
+#' @param covid_regional_data_identifier String, region identifier used by covidregionaldata to get the data. If not supplied
+#' then defaults to `region_name`.
 #' @param case_modifier_function Function, passed the cases, should return the cases. Method of modifying the returned data for a specific region if needed
 #' @param generation_time optional overrides for the loaded rds file. If present won't be reloaded from disk.
 #' @param incubation_period optional overrides for the loaded rds file. If present won't be reloaded from disk.
@@ -44,6 +45,10 @@ update_regional <- function(region_name, covid_regional_data_identifier, case_mo
 
   # Get cases  ---------------------------------------------------------------
   futile.logger::flog.info("Getting regional data")
+  
+  if (missing(covid_regional_data_identifier)) {
+    covid_regional_data_identifier <- region_name
+  }
   
   cases <- data.table::setDT(covidregionaldata::get_regional_data(country = covid_regional_data_identifier, 
                                                                   localise_regions = FALSE))

--- a/R/update-regional.R
+++ b/R/update-regional.R
@@ -22,7 +22,8 @@ source(here::here("R", "utils.R"))
 #' @param cases_subregion_source string, optional specification of where to get the list of regions from the cases dataset
 #' @param region_scale string, specify the region scale to epinow
 update_regional <- function(region_name, covid_regional_data_identifier, case_modifier_function, 
-                            generation_time, incubation_period, reporting_delay, cases_subregion_source, 
+                            generation_time, incubation_period, reporting_delay, 
+                            cases_subregion_source = "region_level_1", 
                             region_scale = "Region") {
   
   # setting debug level to trace whilst still in beta. #ToDo: change this line once production ready
@@ -44,7 +45,8 @@ update_regional <- function(region_name, covid_regional_data_identifier, case_mo
   # Get cases  ---------------------------------------------------------------
   futile.logger::flog.info("Getting regional data")
   
-  cases <- data.table::setDT(covidregionaldata::get_regional_data(country = covid_regional_data_identifier))
+  cases <- data.table::setDT(covidregionaldata::get_regional_data(country = covid_regional_data_identifier, 
+                                                                  localise_regions = FALSE))
   if (!missing(case_modifier_function) && typeof(case_modifier_function) == "closure") {
     futile.logger::flog.trace("Modifying regional data")
     cases <- case_modifier_function(cases)

--- a/R/update-russia.R
+++ b/R/update-russia.R
@@ -1,5 +1,3 @@
 source(here::here("R", "update-regional.R"))
 
-update_regional(region_name = "russia",
-                covid_regional_data_identifier = "Russia"
-)
+update_regional(region_name = "russia")

--- a/R/update-united-kingdom.R
+++ b/R/update-united-kingdom.R
@@ -1,5 +1,3 @@
 source(here::here("R", "update-regional.R"))
 
-update_regional("united-kingdom",
-                "UK"
-)
+update_regional("united-kingdom", "UK")

--- a/R/update-united-states.R
+++ b/R/update-united-states.R
@@ -2,5 +2,4 @@ source(here::here("R", "update-regional.R"))
 
 update_regional(region_name = "united-states",
                 covid_regional_data_identifier = "USA",
-                region_scale = "State"
-)
+                region_scale = "State")

--- a/R/update-united-states.R
+++ b/R/update-united-states.R
@@ -2,6 +2,5 @@ source(here::here("R", "update-regional.R"))
 
 update_regional(region_name = "united-states",
                 covid_regional_data_identifier = "USA",
-                cases_subregion_source =  "state",
                 region_scale = "State"
 )


### PR DESCRIPTION
* Makes use of new `localise_regions` arg in `covidregionaldata` to ensure that all regions are returned with the same name. 
* Keeps structure for this to be changed in the future in case different region levels are needed
* Removes this argument from all function calls
* Drops duplication of `covidregionaldata` country name and defaults to `region_name` unless supplied (caps etc handled in `covidregionaldata`.