### PR TITLE
Stop warning propagation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,7 +24,8 @@ Imports:
   here,
   lubridate,
   optparse,
-  R6 (>= 2.4)
+  R6 (>= 2.4),
+  rlang (>= 0.4.7)
 Remotes:
   epiforecasts/EpiNow2,
   epiforecasts/covidregionaldata

--- a/R/run-region-updates.R
+++ b/R/run-region-updates.R
@@ -69,6 +69,7 @@ rru_process_locations <- function(regions, args, excludes, includes) {
                                    }),
                error = function(e) {
                  futile.logger::flog.error("%s: %s - %s", location$name, e$message, toString(e$call))
+                 futile.logger::flog.error(capture.output(trace_back()))
                }
       )
     }else {
@@ -89,5 +90,6 @@ if (sys.nframe() == 0) {
                                }),
            error = function(e) {
              futile.logger::flog.error(e)
+             futile.logger::flog.error(capture.output(trace_back()))
            })
 }

--- a/R/run-region-updates.R
+++ b/R/run-region-updates.R
@@ -5,6 +5,7 @@
 #'
 # Packages
 library(optparse, quietly = TRUE) # bring this in ready for setting up a proper CLI
+library(rlang, quietly = TRUE) # error handling
 
 # Pull in the definition of the regions
 source(here::here("R", "region-list.R"))
@@ -64,6 +65,7 @@ rru_process_locations <- function(regions, args, excludes, includes) {
                                    },
                                    warning = function(w) {
                                      futile.logger::flog.warn("%s: %s - %s", location$name, w$mesage, toString(w$call))
+                                     cnd_muffle(w)
                                    }),
                error = function(e) {
                  futile.logger::flog.error("%s: %s - %s", location$name, e$message, toString(e$call))
@@ -83,6 +85,7 @@ if (sys.nframe() == 0) {
   tryCatch(withCallingHandlers(run_regional_updates(regions = regions, args = args),
                                warning = function(w) {
                                  futile.logger::flog.warn(w)
+                                 cnd_muffle(w)
                                }),
            error = function(e) {
              futile.logger::flog.error(e)


### PR DESCRIPTION
Tidying up the logs. Similar change going into epiforecasts/epinow2#63 to stop the inner propogation
Also adds a stacktrace to the error dump (might as well use some of the other features from the error handling in rlang)