### PR TITLE
Update for epinow2

### DIFF
--- a/R/update-delays.R
+++ b/R/update-delays.R
@@ -1,5 +1,4 @@
 # Packages ----------------------------------------------------------------
-
 require(EpiNow2)
 require(covidregionaldata)
 require(data.table)
@@ -10,17 +9,14 @@ require(lubridate)
 generation_time <- get_generation_time(disease = "SARS-CoV-2", source = "ganyani")
 incubation_period <- get_incubation_period(disease = "SARS-CoV-2", source = "lauer")
 
-
 saveRDS(generation_time , here::here("data", "generation_time.rds"))
 saveRDS(incubation_period, here::here("data", "incubation_period.rds"))
-
 
 # Set up parallel ---------------------------------------------------------
 if (!interactive()) {
   ## If running as a script enable this
   options(future.fork.enable = TRUE)
 }
-
 
 plan(multiprocess)
 

--- a/R/update-delays.R
+++ b/R/update-delays.R
@@ -7,18 +7,8 @@ require(future)
 require(lubridate)
 
 # Save incubation period and generation time ------------------------------
-
-generation_time <- list(mean = EpiNow2::covid_generation_times[1, ]$mean,
-                        mean_sd = EpiNow2::covid_generation_times[1, ]$mean_sd,
-                        sd = EpiNow2::covid_generation_times[1, ]$sd,
-                        sd_sd = EpiNow2::covid_generation_times[1, ]$sd_sd,
-                        max = 30)
-
-incubation_period <- list(mean = EpiNow2::covid_incubation_period[1, ]$mean,
-                          mean_sd = EpiNow2::covid_incubation_period[1, ]$mean_sd,
-                          sd = EpiNow2::covid_incubation_period[1, ]$sd,
-                          sd_sd = EpiNow2::covid_incubation_period[1, ]$sd_sd,
-                          max = 30)
+generation_time <- get_generation_time(disease = "SARS-CoV-2", source = "ganyani")
+incubation_period <- get_incubation_period(disease = "SARS-CoV-2", source = "lauer")
 
 
 saveRDS(generation_time , here::here("data", "generation_time.rds"))
@@ -26,7 +16,6 @@ saveRDS(incubation_period, here::here("data", "incubation_period.rds"))
 
 
 # Set up parallel ---------------------------------------------------------
-
 if (!interactive()) {
   ## If running as a script enable this
   options(future.fork.enable = TRUE)
@@ -36,14 +25,11 @@ if (!interactive()) {
 plan(multiprocess)
 
 # Fit delay from onset to admission ---------------------------------------
-
 report_delay <- covidregionaldata::get_linelist(report_delay_only = TRUE)
 report_delay <- data.table::as.data.table(report_delay)[!(country %in% c("Mexico", "Phillipines"))]
 
 onset_to_admission_delay <- EpiNow2::bootstrapped_dist_fit(report_delay$days_onset_to_report, bootstraps = 100, 
-                                                           bootstrap_samples = 250)
-## Set max allowed delay to 30 days to truncate computation
-onset_to_admission_delay$max <- 30
+                                                           bootstrap_samples = 250, max_value = 30)
 
 saveRDS(onset_to_admission_delay, here::here("data", "onset_to_admission_delay.rds"))
 

--- a/R/update-regional.R
+++ b/R/update-regional.R
@@ -97,14 +97,13 @@ update_regional <- function(location, excludes, includes, force, max_execution_t
     out <- regional_epinow(reported_cases = cases,
                            generation_time = location$generation_time,
                            delays = list(location$incubation_period, location$reporting_delay),
-                           non_zero_points = 14, horizon = 14,
-                           burn_in = 14, samples = 4000,
-                           warmup = 500, fixed_future_rt = TRUE, cores = no_cores,
-                           chains = ifelse(no_cores <= 4, 4, no_cores),
-                           target_folder = location$target_folder,
+                           non_zero_points = 14, horizon = 14, burn_in = 14, samples = 4000,
+                           stan_args = list(warmup = 500, cores = no_cores, 
+                                            chains = ifelse(no_cores <= 4, 4, no_cores)),
+                           fixed_future_rt = TRUE,  target_folder = location$target_folder,
                            return_estimates = FALSE, summary = TRUE,
-                           verbose = FALSE, return_timings = TRUE,
-                           future = TRUE, max_execution_time = max_execution_time)
+                           return_timings = TRUE, future = TRUE,
+                           max_execution_time = max_execution_time)
     futile.logger::flog.debug("resetting future plan to sequential")
     future::plan("sequential")
     


### PR DESCRIPTION
This PR updates usage of EpiNow2 to match the new interface. This includes updating the arguments passed to `regional_epinow` and the wrapper function used to define delays (though does not alter the delays themselves).

Depends on/blocked by epiforecasts/EpiNow2#74
