### PR TITLE
Update utils.R

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -24,7 +24,7 @@ setup_log_from_args <- function(args) {
 }
 
 #' Set up parallel processing on all available cores
-setup_future <- function(jobs, min_cores_per_worker = 1) {
+setup_future <- function(jobs, min_cores_per_worker = 4) {
   if (!interactive()) {
     ## If running as a script enable this
     options(future.fork.enable = TRUE)


### PR DESCRIPTION
This PR increases the minimum number of cores per worker from 1 to 4. The reason for this change it to attempt to deal with the recent increase in runtimes observed in the last week. This increase was due to the changes introduced in #52 which changed the definition of the timeout from over an entire region to over a single chain in this region. When using a single core per worker this potentially increased the allowed timeout from 2 hours to 8 hours for a single region (as run sequentially and not in parallel).  

Increasing the minimum number of cores per worker should combine the benefits of the new timeout feature for small regions (killing rogue chains and letting estimates be returned) with efficient estimation of longer running/hard to estimate chains (national cases and regional cases etc). It may also not work as intended but given the potential benefits should be tested in production (as it is unlikely to make the situation drastically worse) for several updates at which point it can be evaluated and potentially reverted. Another potential change is to drastically reduce the timeout horizon as the previous testing is no longer relevant (as the timeout definition has changed). This may have some knock-on negative effects, however, and so should be tested prior to being put into production. 