### PR TITLE
Streamline new UK datasets

### DIFF
--- a/R/dataset-list.R
+++ b/R/dataset-list.R
@@ -9,11 +9,8 @@ datasets <- c(
   Region$new(name = "united-kingdom", # leaving this as the default UK for historic purposes
              covid_regional_data_identifier = "UK",
              case_modifier = function(cases) {
-               national_cases <- cases[region_level_1 %in% c("England", "Scotland", "Wales", "Northern Ireland")]
-               uk_cases <- data.table::copy(national_cases)[, .(cases_new = sum(cases_new, na.rm = TRUE)),
-                                                              by = c("date")][, region_level_1 := "United Kingdom"]
-               cases <- data.table::rbindlist(list(cases, uk_cases),
-                                               fill = TRUE, use.names = TRUE)},
+               cases <- add_uk(cases)
+               return(cases)},
              data_args = list(nhsregions = TRUE)),
   Region$new(name = "united-kingdom-deaths",
              covid_regional_data_identifier = "UK",
@@ -22,11 +19,8 @@ datasets <- c(
              reporting_delay = readRDS(here::here("data", "cocin_onset_to_death_delay.rds")),
              case_modifier = function(deaths) {
                deaths <- deaths[, cases_new := deaths_new]
-               national_deaths <- deaths[region_level_1 %in% c("England", "Scotland", "Wales", "Northern Ireland")]
-               uk_deaths <- data.table::copy(national_deaths)[, .(cases_new = sum(cases_new, na.rm = TRUE)),
-                                                              by = c("date")][, region_level_1 := "United Kingdom"]
-               deaths <- data.table::rbindlist(list(deaths, uk_deaths),
-                                                   fill = TRUE, use.names = TRUE)},
+               deaths <- add_uk(deaths)
+               return(deaths)},
              data_args = list(nhsregions = TRUE)),
   Region$new(name = "united-kingdom-admissions",
              covid_regional_data_identifier = "UK",
@@ -34,11 +28,8 @@ datasets <- c(
              dataset_folder_name = "admissions",
              case_modifier = function(admissions) {
                admissions <- admissions[, cases_new := hosp_new_blend]
-               national_admissions <- admissions[region_level_1 %in% c("England", "Scotland", "Wales", "Northern Ireland")]
-               uk_admissions <- data.table::copy(national_admissions)[, .(cases_new = sum(cases_new, na.rm = TRUE)),
-                                                                by = c("date")][, region_level_1 := "United Kingdom"]
-               admissions <- data.table::rbindlist(list(admissions, uk_admissions),
-                                                       fill = TRUE, use.names = TRUE)},
+               admissions <- add_uk(admissions)
+               return(admissions)},
              data_args = list(nhsregions = TRUE)),
   Region$new(name = "united-states",
              covid_regional_data_identifier = "USA",

--- a/R/dataset-list.R
+++ b/R/dataset-list.R
@@ -28,7 +28,7 @@ datasets <- c(
              dataset_folder_name = "admissions",
              case_modifier = function(admissions) {
                admissions <- admissions[, cases_new := hosp_new_blend]
-               admissions <- add_uk(admissions)
+               admissions <- add_uk(admissions, min_uk = "01-08-2020")
                return(admissions)},
              data_args = list(nhsregions = TRUE)),
   Region$new(name = "united-states",

--- a/R/dataset-list.R
+++ b/R/dataset-list.R
@@ -28,7 +28,6 @@ datasets <- c(
              dataset_folder_name = "admissions",
              case_modifier = function(admissions) {
                admissions <- admissions[, cases_new := hosp_new_blend]
-               admissions <- add_uk(admissions, min_uk = "01-08-2020")
                return(admissions)},
              data_args = list(nhsregions = TRUE)),
   Region$new(name = "united-states",

--- a/R/utils.R
+++ b/R/utils.R
@@ -160,3 +160,14 @@ collate_estimates <- function(name, target = "rt"){
   return(invisible(NULL))
 
 }
+
+#' Adds a UK case count to a dataset usng national level data
+add_uk <- function(cases){
+  national_cases <- cases[region_level_1 %in% c("England", "Scotland", "Wales", "Northern Ireland")]
+  uk_cases <- data.table::copy(national_cases)[, .(cases_new = sum(cases_new, na.rm = TRUE)), by = c("date")]
+  uk_cases <- uk_cases[, region_level_1 := "United Kingdom"]
+  cases <- data.table::rbindlist(list(cases, uk_cases), fill = TRUE, use.names = TRUE)
+  return(cases)
+  }
+ 
+

--- a/R/utils.R
+++ b/R/utils.R
@@ -162,10 +162,15 @@ collate_estimates <- function(name, target = "rt"){
 }
 
 #' Adds a UK case count to a dataset usng national level data
-add_uk <- function(cases){
+add_uk <- function(cases, min_uk){
   national_cases <- cases[region_level_1 %in% c("England", "Scotland", "Wales", "Northern Ireland")]
   uk_cases <- data.table::copy(national_cases)[, .(cases_new = sum(cases_new, na.rm = TRUE)), by = c("date")]
   uk_cases <- uk_cases[, region_level_1 := "United Kingdom"]
+  
+  if (!missing(min_uk)) {
+    uk_cases <- uk_cases[date >= as.Date(min_uk)]
+    }
+  
   cases <- data.table::rbindlist(list(cases, uk_cases), fill = TRUE, use.names = TRUE)
   return(cases)
   }


### PR DESCRIPTION
The current implementation of the new datasets uses the same essential code 3 times in order to add a UK level dataset. This adds additional length to `dataset-list.R` and may introduce issues in the longer term. This PR implements a function that reproduces these steps and replaces the copied code with a call to this function. My understanding on the source chain is that this function will be available whenever the entity in dataset-list is used and so this will work as is without anyother modifications. 