### PR TITLE
Make truncation set across regions

### DIFF
--- a/R/entities.R
+++ b/R/entities.R
@@ -9,6 +9,7 @@ AbstractDataset <- R6Class("AbstractDataset", list(
   incubation_period = NA,
   reporting_delay = NA,
   region_scale = NA,
+  truncation = NA,
   stable = TRUE,
   target_folder = NA,
   summary_dir = NA
@@ -24,6 +25,7 @@ SuperRegion <- R6Class("SuperRegion",
                                                            incubation_period = NA,
                                                            reporting_delay = NA,
                                                            region_scale = "Country",
+                                                           truncation = 3,
                                                            stable = TRUE,
                                                            folder_name = NA) {
                                        self$name <- name
@@ -34,6 +36,7 @@ SuperRegion <- R6Class("SuperRegion",
                                        self$reporting_delay <- reporting_delay
                                        self$region_scale <- region_scale
                                        self$stable <- stable
+                                       self$truncation <- truncation
                                        highest_folder <- ifelse(region_scale == "Country", "national/", "region/")
                                        middle_folder <- ifelse(is.na(folder_name), name, folder_name)
                                        tail_target_folder <- ifelse(region_scale == "Country", "/national", "/region")
@@ -55,12 +58,14 @@ Region <- R6Class("Region",
                                                       cases_subregion_source = "region_level_1",
                                                       data_args = NULL,
                                                       region_scale = "Region",
+                                                      truncation = 3,
                                                       stable = TRUE,
                                                       folder_name = NA,
                                                       dataset_folder_name = "cases") {
                                   self$name <- name
                                   self$covid_regional_data_identifier <- covid_regional_data_identifier
                                   self$data_args <- data_args
+                                  self$truncation <- truncation
                                   self$case_modifier <- case_modifier
                                   self$generation_time <- generation_time
                                   self$incubation_period <- incubation_period

--- a/R/update-regional.R
+++ b/R/update-regional.R
@@ -82,7 +82,7 @@ update_regional <- function(location, excludes, includes, force, max_execution_t
     cases <- cases[region %in_ci% includes$subregion]
   }
 
-  cases <- clean_regional_data(cases)
+  cases <- clean_regional_data(cases, truncation = location$truncation)
 
   # Check to see if there is data and if the data has been updated  ------------------------------
   if (cases[, .N] > 0 && (force || check_for_update(cases, last_run = here::here("last-update", paste0(location$name, ".rds"))))) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -71,11 +71,11 @@ check_for_update <- function(cases, last_run) {
 }
 
 #' Clean regional data
-clean_regional_data <- function(cases) {
+clean_regional_data <- function(cases, truncation = 3) {
   futile.logger::flog.trace("starting to clean the cases")
   cases <- cases[, .(region, date = as.Date(date), confirm = cases_new)]
   cases <- cases[date <= Sys.Date()]
-  cases <- cases[, .SD[date <= (max(date, na.rm = TRUE) - lubridate::days(3))], by = region]
+  cases <- cases[, .SD[date <= (max(date, na.rm = TRUE) - lubridate::days(truncation))], by = region]
   cases <- cases[, .SD[date >= (max(date) - lubridate::weeks(12))], by = region]
   cases <- cases[!is.na(confirm)]
   data.table::setorder(cases, date)


### PR DESCRIPTION
This PR adds support for region-specific truncation after discussion with @kathsherratt about the UK data. At the moment this is set to the current default everywhere (3 days) but this can now be tuned dataset by dataset as new evidence becomes available (like run time analysis etc).