### PR TITLE
Remove outdated files

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -150,6 +150,9 @@ collate_estimates <- function(name, target = "rt"){
   df <- data.table::rbindlist(df, idcol = "source")
   df <- df[type %in% "estimate"][, type := NULL]
   
+  # Remove any deprecated regions
+  df <- df[!region %in% c("North East", "Yorkshire and The Humber", "East Midlands", "West Midlands")]
+
   # Check a collated file exists
   if(!dir.exists(here::here("subnational", name, "collated", target))){
     dir.create(here::here("subnational", name, "collated", target), recursive = TRUE)


### PR DESCRIPTION
Four regions get merged (into North East and Yorkshire and Midlands) before new Rt estimates are made, but are not removed from the `collated.csv` output. This means we have outdated estimates in the output.

- `R/utils.R` - Adding code to ensure these regions are removed from collated csv output before this is saved

- We could also delete the actual files. Not adding to this PR but this would include:
  - `subnational/united-kingdom/cases/national` and `.../deaths/national`
    - `.../Yorkshire and The Humber`
    - `.../North East`
    - `.../West Midlands`
    - `.../East Midlands`