### PR TITLE
Add truncation for UK

### DIFF
--- a/R/dataset-list.R
+++ b/R/dataset-list.R
@@ -11,7 +11,8 @@ datasets <- c(
              case_modifier = function(cases) {
                cases <- add_uk(cases)
                return(cases)},
-             data_args = list(nhsregions = TRUE)),
+             data_args = list(nhsregions = TRUE),
+             truncation = 5),
   Region$new(name = "united-kingdom-deaths",
              covid_regional_data_identifier = "UK",
              folder_name = "united-kingdom",


### PR DESCRIPTION
Aims to address issue #88 by increasing truncation to 5 days in the UK test-positive cases data. Deaths and admissions Rts don't look like they are suffering the same issue so no changes there.

Discussed this with @sbfnk, where we reviewed UK data and recent estimates of delays from lab test to report. Decision was to truncate at 5 days: truncation at 3 days looks insufficient, 4 days is enough to capture most of the data, plus 1 day feed through into the public PHE dataset.

@joeHickson - from what I can see in the code it looks like all I need to do here is add an extra `truncation` parameter, that gets fed through into the cleaning functions (where the default param is set to 3). I have opened this PR to do this - would that work?