### PR TITLE
Update DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,7 +22,7 @@ Encoding: UTF-8
 LazyData: true
 Imports:
   EpiNow2 (>= 1.2.0),
-  covidregionaldata (>= 0.7.0),
+  covidregionaldata (>= 0.8.0),
   data.table,
   dplyr (>= 1.0.0),
   futile.logger (>= 1.4),


### PR DESCRIPTION
Updates to use `covidregionaldata 0.8.0` which only contains changes to keep data sources current. See [here](https://github.com/epiforecasts/covidregionaldata/commits/master) for commit history since the last release.