### PR TITLE
Switches to patched futile.logger

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -40,7 +40,7 @@ Suggests:
     desc,
     testthat
 Remotes:
-  joeHickson/futile.logger,
+  joeHickson/futile.logger@i67_ftry,
   epiforecasts/EpiNow2@v1.3.2,
   epiforecasts/covidregionaldata@v0.8.1
 Roxygen: list(markdown = TRUE)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -40,6 +40,7 @@ Suggests:
     desc,
     testthat
 Remotes:
+  joeHickson/futile.logger,
   epiforecasts/EpiNow2@v1.3.2,
   epiforecasts/covidregionaldata@v0.8.1
 Roxygen: list(markdown = TRUE)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -40,7 +40,7 @@ Suggests:
     desc,
     testthat
 Remotes:
-  joeHickson/futile.logger@i67_ftry,
+  joeHickson/futile.logger,
   epiforecasts/EpiNow2@v1.3.2,
   epiforecasts/covidregionaldata@v0.8.1
 Roxygen: list(markdown = TRUE)

--- a/R/update-regional.R
+++ b/R/update-regional.R
@@ -127,20 +127,19 @@ update_regional <- function(location, excludes, includes, force, max_execution_t
                                        future = FALSE, max_execution_time = max_execution_time),
                       target_folder = location$target_folder,
                       output = c("plots", "latest"),
-                      non_zero_points = 14, horizon = 14, logs = NULL)
+                      non_zero_points = 14, horizon = 14, logs = NULL), silent = TRUE
     )
     futile.logger::flog.debug("resetting future plan to sequential")
     future::plan("sequential")
 
     futile.logger::flog.trace("generating summary data")
-    try(futile.logger::ftry(regional_summary(
+    futile.logger::ftry(regional_summary(
       reported_cases = cases,
       results_dir = location$target_folder,
       summary_dir = location$summary_dir,
       region_scale = location$region_scale,
       all_regions = "Region" %in% class(location),
-      return_output = FALSE
-    )), silent = TRUE)
+      return_output = FALSE), silent = TRUE)
     out <- list()
     futile.logger::flog.trace("reading runtimes.csv")
     timings <- data.table::fread(paste0(location$target_folder, "/runtimes.csv"))


### PR DESCRIPTION
Closes #141 by switching to the patched version of `futile.logger` that properly handles errors. Also drops now not needed  `try` calls. 