### PR TITLE
Drop default truncation to 0

### DIFF
--- a/R/entities/abstract-dataset.R
+++ b/R/entities/abstract-dataset.R
@@ -51,7 +51,7 @@ AbstractDataset <- R6::R6Class("AbstractDataset",
                                    reporting_delay = NA,
                                    stable = TRUE,
                                    data_args = NULL,
-                                   truncation = 3
+                                   truncation = 0
                                  ) {
 
                                    if (!PublicationMetadata$classname %in% class(publication_metadata)) {

--- a/R/lists/dataset-list.R
+++ b/R/lists/dataset-list.R
@@ -35,7 +35,8 @@ DATASETS <- list(
                                          deaths <- deaths[, cases_new := deaths_new]
                                          deaths <- add_uk(deaths)
                                          return(deaths) },
-                                       data_args = list(nhsregions = TRUE)),
+                                       data_args = list(nhsregions = TRUE),
+                                       truncation = 3),
   "united-kingdom-admissions" = Region$new(name = "united-kingdom-admissions",
                                            publication_metadata = PublicationMetadata$new(
                                              title = "National and Subnational Estimates of the Covid 19 Reproduction Number (R) for the United Kingdom Based on Hospital Admissions",
@@ -48,7 +49,8 @@ DATASETS <- list(
                                            case_modifier = function(admissions) {
                                              admissions <- admissions[, cases_new := hosp_new_blend]
                                              return(admissions) },
-                                           data_args = list(nhsregions = TRUE)),
+                                           data_args = list(nhsregions = TRUE),
+                                           truncation = 3),
   "united-states" = Region$new(name = "united-states",
                                publication_metadata = PublicationMetadata$new(
                                  title = "National and Subnational Estimates of the Covid 19 Reproduction Number (R) for the United States of America Based on Test Results",


### PR DESCRIPTION
Changes default truncation to 0, but keeps truncation as is in the UK. 

The motivation for this PR is that the original truncation setting was a temporary feature that it was hoped would either be replaced by an automated checking approach, data based correction (which is in place in `EpiNow2` but not currently supported here), or manual checks (with the UK only having been checked). 

Unfortunately, due to lack of resources, this has not happened. In the short term, it seems best to roll back to using no truncation anywhere and then assess data sources over time (using the reported_cases.csv that will be saved as estimates are produced) to explore truncation and updates the defaults per data source this can likely happen within a few days so potentially spurious estimates will be a short term issue (rather than the current continual issue of overly lagged estimates). 