### PR TITLE
update national identifier in a second place

### DIFF
--- a/R/entities/super-region.R
+++ b/R/entities/super-region.R
@@ -25,7 +25,7 @@ SuperRegion <- R6::R6Class("SuperRegion",
                                                                #' folder_name = "united-kingdom"
                                                                #' @return a new `SuperRegion` object
                                          initialize = function(...,
-                                                               covid_national_data_identifier = "ecdc",
+                                                               covid_national_data_identifier = "who",
                                                                region_scale = "Country",
                                                                folder_name = NA) {
                                            super$initialize(..., region_scale)


### PR DESCRIPTION
I don't really understand why this is defined in two different places. It's a shot in the dark because most runs are failing without error logging so perhaps this helps (and it can't get worse).