### PR TITLE
Truncation for hospital admissions in DAs

### DIFF
--- a/R/lists/dataset-list.R
+++ b/R/lists/dataset-list.R
@@ -52,7 +52,7 @@ DATASETS <- list(
                                              england <- data.table::copy(admissions)[!(region_level_1 %in% c("Scotland", "Wales", "Northern Ireland"))]
                                              admissions <- admissions[region_level_1 %in% c("Scotland", "Wales", "Northern Ireland"),
                                                                       .SD[date <= (max(date) - 3)], by = "region_level_1"]
-                                             admissions <- data.table::rbindlist(list(england, admissions))
+                                             admissions <- data.table::rbindlist(list(england, admissions), use.names = TRUE)
                                              return(admissions) },
                                            data_args = list(nhsregions = TRUE)),
   "united-kingdom-local" = Region$new(name = "united-kingdom-local",

--- a/R/lists/dataset-list.R
+++ b/R/lists/dataset-list.R
@@ -49,8 +49,10 @@ DATASETS <- list(
                                            dataset_folder_name = "admissions",
                                            case_modifier = function(admissions) {
                                              admissions <- admissions[, cases_new := hosp_new_blend]
+                                             england <- data.table::copy(admissions)[!(region_level_1 %in% c("Scotland", "Wales", "Northern Ireland"))]
                                              admissions <- admissions[region_level_1 %in% c("Scotland", "Wales", "Northern Ireland"),
                                                                       .SD[date <= (max(date) - 3)], by = "region_level_1"]
+                                             admissions <- data.table::rbindlist(list(england, admissions))
                                              return(admissions) },
                                            data_args = list(nhsregions = TRUE)),
   "united-kingdom-local" = Region$new(name = "united-kingdom-local",

--- a/R/lists/dataset-list.R
+++ b/R/lists/dataset-list.R
@@ -49,8 +49,8 @@ DATASETS <- list(
                                            dataset_folder_name = "admissions",
                                            case_modifier = function(admissions) {
                                              admissions <- admissions[, cases_new := hosp_new_blend]
-                                             admissions <- admissions[region %in% c("Scotland", "Wales", "Northern Ireland"),
-                                                                      .SD[date <= (max(date) - 3)], by = "region"]
+                                             admissions <- admissions[region_level_1 %in% c("Scotland", "Wales", "Northern Ireland"),
+                                                                      .SD[date <= (max(date) - 3)], by = "region_level_1"]
                                              return(admissions) },
                                            data_args = list(nhsregions = TRUE)),
   "united-kingdom-local" = Region$new(name = "united-kingdom-local",

--- a/R/lists/dataset-list.R
+++ b/R/lists/dataset-list.R
@@ -49,6 +49,8 @@ DATASETS <- list(
                                            dataset_folder_name = "admissions",
                                            case_modifier = function(admissions) {
                                              admissions <- admissions[, cases_new := hosp_new_blend]
+                                             admissions <- admissions[region %in% c("Scotland", "Wales", "Northern Ireland"),
+                                                                      .SD[date <= (max(date) - 3)], by = "region"]
                                              return(admissions) },
                                            data_args = list(nhsregions = TRUE)),
   "united-kingdom-local" = Region$new(name = "united-kingdom-local",

--- a/R/lists/dataset-list.R
+++ b/R/lists/dataset-list.R
@@ -49,10 +49,15 @@ DATASETS <- list(
                                            dataset_folder_name = "admissions",
                                            case_modifier = function(admissions) {
                                              admissions <- admissions[, cases_new := hosp_new_blend]
-                                             england <- data.table::copy(admissions)[!(region_level_1 %in% c("Scotland", "Wales", "Northern Ireland"))]
-                                             admissions <- admissions[region_level_1 %in% c("Scotland", "Wales", "Northern Ireland"),
-                                                                      .SD[date <= (max(date) - 3)], by = "region_level_1"]
-                                             admissions <- data.table::rbindlist(list(england, admissions), use.names = TRUE)
+                                             england <- data.table::copy(admissions)[region_level_1 == "England"]
+                                             scotland <- admissions[region_level_1 == "Scotland",
+                                                                    .SD[date <= (max(date) - 4)], by = "region_level_1"]
+                                             wales <- admissions[region_level_1 == "Wales",
+                                                                 .SD[date <= (max(date) - 2)], by = "region_level_1"]
+                                             ni <- admissions[region_level_1 == "Northern Ireland",
+                                                              .SD[date <= (max(date) - 2)], by = "region_level_1"]
+                                             admissions <- data.table::rbindlist(list(england, scotland, wales, ni), 
+                                                                                 use.names = TRUE)
                                              return(admissions) },
                                            data_args = list(nhsregions = TRUE)),
   "united-kingdom-local" = Region$new(name = "united-kingdom-local",


### PR DESCRIPTION
This PR adds a basic truncation for hospital admissions in DAs. 

It is untested but if it works on the raw data (i.e on the output from `covidregionaldata`) it should work in the pipeline. 