### PR TITLE
Add UK region to admissions 

### DIFF
--- a/R/case-manipulation-utils.R
+++ b/R/case-manipulation-utils.R
@@ -1,8 +1,9 @@
 #' Adds a UK case count to a dataset usng national level data
 add_uk <- function(cases, min_uk) {
   national_cases <- cases[region_level_1 %in% c("England", "Scotland", "Wales", "Northern Ireland")]
-  uk_cases <- data.table::copy(national_cases)[, .(cases_new = sum(cases_new, na.rm = TRUE)), by = c("date")]
+  uk_cases <- data.table::copy(national_cases)[, .(cases_new = sum(cases_new)), by = c("date")]
   uk_cases <- uk_cases[, region_level_1 := "United Kingdom"]
+  uk_cases <- uk_cases[!is.na(cases_new)]
 
   if (!missing(min_uk)) {
     uk_cases <- uk_cases[date >= as.Date(min_uk)]

--- a/R/lists/dataset-list.R
+++ b/R/lists/dataset-list.R
@@ -58,6 +58,7 @@ DATASETS <- list(
                                                               .SD[date <= (max(date) - 2)], by = "region_level_1"]
                                              admissions <- data.table::rbindlist(list(england, scotland, wales, ni), 
                                                                                  use.names = TRUE)
+                                             admissions <- add_uk(admissions)
                                              return(admissions) },
                                            data_args = list(nhsregions = TRUE)),
   "united-kingdom-local" = Region$new(name = "united-kingdom-local",


### PR DESCRIPTION
Adds UK as a region in admissions data, as cases and deaths have.

Not sure if this was causing the data truncation step to be skipped or fail.

Related - wonder if we should drop the arg `rm.na = TRUE` in the `add_uk()` function when summing nations. Currently all NAs get converted to 0 and summed, which is not that helpful when this happens in the most recent dates.