### PR TITLE
Debugs pipeline to fix all location failure

### DIFF
--- a/R/lists/dataset-list.R
+++ b/R/lists/dataset-list.R
@@ -222,7 +222,7 @@ DATASETS <- list(
 )
 
 for (location in DATASETS) {
-  location <- rlang::duplicate(location)
+  location <- location$clone()
   location$name <- paste0(location$name, '-full')
   split_loc_path <- strsplit(location$target_folder, "/")
   split_loc_path[[1]][2] <- paste0(split_loc_path[[1]][2], '-full')


### PR DESCRIPTION
Quite a tangled web in the code but I think this copying issue gets to the bottom of it. As explained in #197 I think this is due to the overwriting the original data set definition with full leading to issues with control code down the line in way that for me were quite unexpected. 


I ran through the code up to triggering a run and see this so 🤞🏻 

```
r$> example_non_cli_trigger()                                                                            
2021-05-11 17:14:57 TRACE run_regional_updates
2021-05-11 17:14:57 TRACE process includes
2021-05-11 17:14:57 TRACE filter datasets
2021-05-11 17:14:57 TRACE process locations
2021-05-11 17:14:57 INFO Processing dataset for canada
2021-05-11 17:14:57 TRACE loading ancillary data
2021-05-11 17:14:57 TRACE loading cases
2021-05-11 17:14:57 INFO Getting regional data
Downloading data from https://health-infobase.canada.ca/src/data/covidLive/covid19.csv
Rows: 6,447                                                                                            
Columns: 41
Delimiter: ","
chr [ 4]: prname, prnameFR, date, percentrecover
dbl [37]: pruid, update, numconf, numprob, numdeaths, numtotal, numtested, numtests, numrecover, ratetested, ratete...

Use `spec()` to retrieve the guessed column specification
Pass a specification to the `col_types` argument to quiet this message
Cleaning data
Processing data
2021-05-11 17:14:59 TRACE Remapping case data with level_1_region as region source
2021-05-11 17:14:59 TRACE starting to clean the cases
2021-05-11 17:14:59 DEBUG New data to process
2021-05-11 17:14:59 INFO Using 4 workers with 4 cores per worker
2021-05-11 17:14:59 DEBUG Checking the cores available - 16 cores and 14 jobs. Using 14 workers
2021-05-11 17:14:59 TRACE calling regional_epinow
2021-05-11 17:14:59 INFO Producing following optional outputs: plots, latest
2021-05-11 17:14:59 INFO Reporting estimates using data up to: 2021-05-10
2021-05-11 17:14:59 INFO Saving estimates to : subnational/canada/cases/national
2021-05-11 17:14:59 INFO Producing estimates for: Alberta, British Columbia, Manitoba, New Brunswick, Newfoundland and Labrador, Northwest Territories, Nova Scotia, Nunavut, Ontario, Prince Edward Island, Quebec, Saskatchewan
2021-05-11 17:14:59 INFO Regions excluded: Repatriated Travellers, Yukon
2021-05-11 17:14:59 TRACE calling future apply to process each region through the run_region function
  |                                                                                               |   0%
```