### PR TITLE
Silences covidregionaldata

### DIFF
--- a/R/lists/dataset-list.R
+++ b/R/lists/dataset-list.R
@@ -222,7 +222,7 @@ DATASETS <- list(
 )
 
 for (location in DATASETS) {
-  location <- rlang::duplicate(location)
+  location <- location$clone()
   location$name <- paste0(location$name, '-full')
   split_loc_path <- strsplit(location$target_folder, "/")
   split_loc_path[[1]][2] <- paste0(split_loc_path[[1]][2], '-full')

--- a/R/update-regional.R
+++ b/R/update-regional.R
@@ -50,12 +50,14 @@ update_regional <- function(location, excludes, includes, force, max_execution_t
       futile.logger::flog.info("Getting regional data")
       
       cases <- do.call(covidregionaldata::get_regional_data, c(list(country = location$covid_regional_data_identifier,
-                                                                    localise = FALSE), #suggest moving into list def
+                                                                    localise = FALSE,
+                                                                    verbose = FALSE), #suggest moving into list def
                                                                location$data_args))
       cases <- data.table::setDT(cases)
     }else if ("SuperRegion" %in% class(location)) {
       futile.logger::flog.info("Getting national data for %s", location$name)
-      cases <- data.table::setDT(covidregionaldata::get_national_data(source = location$covid_national_data_identifier)) #suggest moving into list def
+      cases <- data.table::setDT(covidregionaldata::get_national_data(source = location$covid_national_data_identifier, 
+      verbose = FALSE)) #suggest moving into list def
     }
   }else{
     futile.logger::flog.info("Getting data")
@@ -107,10 +109,8 @@ update_regional <- function(location, excludes, includes, force, max_execution_t
     futile.logger::flog.trace("Filtering out not included regions")
     cases <- cases[region %in_ci% include_subregions]
   }
-
   cases <- clean_regional_data(cases, truncation = location$truncation,
                                data_window = location$data_window)
-
   # Check to see if there is data and if the data has been updated  ------------------------------
   if (cases[, .N] > 0 && (force || check_for_update(cases, last_run = here::here("last-update", paste0(location$name, ".rds"))))) {
     # Set up cores -----------------------------------------------------


### PR DESCRIPTION

Silences verbose messages in `covidregionaldata 0.9.0` and onwards. 

Test on example: 

```
r$> source("/home/covidrtestimates/covid-rt-estimates/R/run-region-updates.R", encoding = "UTF-8")       

r$> example_non_cli_trigger()                                                                            
2021-05-11 17:28:04 TRACE run_regional_updates
2021-05-11 17:28:04 TRACE process includes
2021-05-11 17:28:04 TRACE filter datasets
2021-05-11 17:28:04 TRACE process locations
2021-05-11 17:28:04 INFO Processing dataset for canada
2021-05-11 17:28:04 TRACE loading ancillary data
2021-05-11 17:28:04 TRACE loading generation_time.rds
2021-05-11 17:28:04 TRACE loading incubation_period.rds
2021-05-11 17:28:04 TRACE loading onset_to_admission_delay.rds
2021-05-11 17:28:04 TRACE loading cases
2021-05-11 17:28:04 INFO Getting regional data
2021-05-11 17:28:07 TRACE Remapping case data with level_1_region as region source
2021-05-11 17:28:07 TRACE starting to clean the cases
2021-05-11 17:28:07 DEBUG New data to process
2021-05-11 17:28:07 INFO Using 4 workers with 4 cores per worker
2021-05-11 17:28:07 DEBUG Checking the cores available - 16 cores and 14 jobs. Using 14 workers
2021-05-11 17:28:07 TRACE calling regional_epinow
2021-05-11 17:28:07 INFO Producing following optional outputs: plots, latest
2021-05-11 17:28:07 INFO Reporting estimates using data up to: 2021-05-10
2021-05-11 17:28:07 INFO Saving estimates to : subnational/canada/cases/national
2021-05-11 17:28:07 INFO Producing estimates for: Alberta, British Columbia, Manitoba, New Brunswick, Newfoundland and Labrador, Northwest Territories, Nova Scotia, Nunavut, Ontario, Prince Edward Island, Quebec, Saskatchewan
2021-05-11 17:28:07 INFO Regions excluded: Repatriated Travellers, Yukon
2021-05-11 17:28:07 TRACE calling future apply to process each region through the run_region function
  |                                                                                               |   0%
```