### PR TITLE
Drops depreciated args

### DIFF
--- a/R/lists/dataset-list.R
+++ b/R/lists/dataset-list.R
@@ -63,7 +63,7 @@ DATASETS <- list(
                                       cases_subregion_source = "level_2_region",
                                       covid_regional_data_identifier = "UK",
                                       reporting_delay = readRDS(here::here("data", "uk_onset_to_case.rds")),
-                                      data_args = list(include_level_2_regions = TRUE),
+                                      data_args = list(level = "2"),
                                       truncation = 4),
   "united-kingdom-local-deaths" = Region$new(name = "united-kingdom-local-deaths",
                                       publication_metadata = PublicationMetadata$new(
@@ -73,7 +73,7 @@ DATASETS <- list(
                                         country = "United Kingdom"),
                                       cases_subregion_source = "level_2_region",
                                       covid_regional_data_identifier = "UK",
-                                      data_args = list(include_level_2_regions = TRUE),
+                                      data_args = list(level = "2"),
                                       folder_name = "united-kingdom-local",
                                       dataset_folder_name = "deaths",
                                       reporting_delay = readRDS(here::here("data", "cocin_onset_to_death_delay.rds")),


### PR DESCRIPTION
The batch run is failing with the following log messages: 

```
2021-05-12 01:33:06 TRACE run_regional_updates
2021-05-12 01:33:06 TRACE process includes
2021-05-12 01:33:07 TRACE filter datasets
2021-05-12 01:33:07 TRACE process locations
2021-05-12 01:33:07 INFO Processing dataset for united-kingdom-local
2021-05-12 01:33:07 TRACE loading ancillary data
2021-05-12 01:33:07 TRACE loading generation_time.rds
2021-05-12 01:33:07 TRACE loading incubation_period.rds
2021-05-12 01:33:07 TRACE loading cases
2021-05-12 01:33:07 INFO Getting regional data
2021-05-12 01:33:07 WARN lifecycle_warning_deprecated: The `include_level_2_regions` argument of `get_regional_data()` is deprecated as of covidregionaldata 0.9.0.
Please use the `level` argument instead.
This warning is displayed once every 8 hours.
Call `lifecycle::last_warnings()` to see where this warning was generated.

2021-05-12 01:33:07 WARN simpleWarning in gsub("~m", msg, message, fixed = TRUE): argument 'replacement' has length > 1 and only the first element will be used

2021-05-12 01:33:07 WARN simpleWarning in gsub("~m", msg, message, fixed = TRUE): argument 'replacement' has length > 1 and only the first element will be used

2021-05-12 01:33:07 DEBUG      █
2021-05-12 01:33:07 WARN united-kingdom-local: lifecycle_warning_deprecated: The `include_level_2_regions` argument of `get_regional_data()` is deprecated as of covidregionaldata 0.9.0.
Please use the `level` argument instead.
This warning is displayed once every 8 hours.
Call `lifecycle::last_warnings()` to see where this warning was generated.

2021-05-12 01:33:11 ERROR invalid source column name level_2_region - only the following are valid
2021-05-12 01:33:11 WARN simpleWarning in gsub("~m", msg, message, fixed = TRUE): argument 'replacement'
```

Here the depreciated args are replaced which appears to solve this ERROR despite them only throwing a warning message and being unrelated to this ERROR message. Given this lack of reproducibility locally it maybe that this is not a complete fix. 